### PR TITLE
Decode adjustments as JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,519 @@
+# photohack
+
+Experimenting with PhotoKit to load non-system photo libraries to decode adjustment data and other useful info.
+
+```sh
+photohack path/to/some.photoslibrary UUID...
+```
+
+## Adjustments Schema
+
+See the debugging section below for a bit more details
+
+TODO: JSON-ify this so it's a bit easier to read
+
+```
+effect3D = {
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+    intensity = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 1;\n    required = 0;\n}>";
+    kind = "<NUEnumSetting values:(\n    3DVivid,\n    3DVividWarm,\n    3DVividCool,\n    3DDramatic,\n    3DDramaticWarm,\n    3DDramaticCool,\n    3DSilverplate,\n    3DNoir\n) attributes:{\n    default = 3DVivid;\n}>";
+    version = "<NUNumberSetting min:0 max:1 attributes:{\n    required = 0;\n}>";
+}
+livePhotoKeyFrame = {
+    scale = "<NUNumberSetting min:1 max:2147483647 attributes:{\n    default = 1;\n}>";
+    time = "<NUNumberSetting min:0 max:9223372036854775807 attributes:{\n}>";
+}
+mute = {
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+}
+whiteBalance = {
+    auto = "<NUBoolSetting attributes:{\n    required = 0;\n}>";
+    colorType = "<NUEnumSetting values:(\n    neutralGray,\n    faceBalance,\n    tempTint,\n    warmTint\n) attributes:{\n    default = faceBalance;\n}>";
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+    faceI = "<NUNumberSetting min:-3 max:3 attributes:{\n    required = 0;\n}>";
+    faceQ = "<NUNumberSetting min:-2 max:2 attributes:{\n    required = 0;\n}>";
+    faceStrength = "<NUNumberSetting min:-3 max:3 attributes:{\n    required = 0;\n}>";
+    faceWarmth = "<NUNumberSetting min:-3 max:3 attributes:{\n    required = 0;\n}>";
+    grayI = "<NUNumberSetting min:-3 max:3 attributes:{\n    required = 0;\n}>";
+    grayQ = "<NUNumberSetting min:-3 max:3 attributes:{\n    required = 0;\n}>";
+    grayStrength = "<NUNumberSetting min:-3 max:3 attributes:{\n    default = 1;\n    required = 0;\n}>";
+    grayWarmth = "<NUNumberSetting min:-3 max:3 attributes:{\n    required = 0;\n}>";
+    grayY = "<NUNumberSetting min:-3 max:3 attributes:{\n    required = 0;\n}>";
+    temperature = "<NUNumberSetting min:1000 max:32000 attributes:{\n    default = 5000;\n    identity = 5000;\n    required = 0;\n}>";
+    tint = "<NUNumberSetting min:-150 max:150 attributes:{\n    default = 0;\n    required = 0;\n}>";
+    warmFace = "<NUBoolSetting attributes:{\n    default = 0;\n    required = 0;\n}>";
+    warmTemp = "<NUNumberSetting min:-2 max:2 attributes:{\n    default = 0;\n    required = 0;\n}>";
+    warmTint = "<NUNumberSetting min:-2 max:2 attributes:{\n    default = 0;\n    required = 0;\n}>";
+}
+vignette = {
+    auto = "<NUBoolSetting attributes:{\n    required = 0;\n}>";
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+    falloff = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 0;\n}>";
+    intensity = "<NUNumberSetting min:-1 max:1 attributes:{\n    default = 0;\n}>";
+    radius = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 0;\n}>";
+}
+definition = {
+    auto = "<NUBoolSetting attributes:{\n    required = 0;\n}>";
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+    intensity = "<NUNumberSetting min:0 max:2 attributes:{\n    default = 0;\n}>";
+}
+levels = {
+    auto = "<NUBoolSetting attributes:{\n    required = 0;\n}>";
+    blackDstBlue = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 0;\n    required = 0;\n}>";
+    blackDstGreen = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 0;\n    required = 0;\n}>";
+    blackDstRGB = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 0;\n    required = 0;\n}>";
+    blackDstRed = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 0;\n    required = 0;\n}>";
+    blackSrcBlue = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 0;\n    required = 0;\n}>";
+    blackSrcGreen = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 0;\n    required = 0;\n}>";
+    blackSrcRGB = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 0;\n    required = 0;\n}>";
+    blackSrcRed = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 0;\n    required = 0;\n}>";
+    colorSpace = "<NUEnumSetting values:(\n    \"Adobe RGB\",\n    sRGB,\n    \"Display P3\"\n) attributes:{\n    default = \"Display P3\";\n    required = 0;\n}>";
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+    hilightDstBlue = "<NUNumberSetting min:0 max:1 attributes:{\n    default = \"0.75\";\n    required = 0;\n}>";
+    hilightDstGreen = "<NUNumberSetting min:0 max:1 attributes:{\n    default = \"0.75\";\n    required = 0;\n}>";
+    hilightDstRGB = "<NUNumberSetting min:0 max:1 attributes:{\n    default = \"0.75\";\n    required = 0;\n}>";
+    hilightDstRed = "<NUNumberSetting min:0 max:1 attributes:{\n    default = \"0.75\";\n    required = 0;\n}>";
+    hilightSrcBlue = "<NUNumberSetting min:0 max:1 attributes:{\n    default = \"0.75\";\n    required = 0;\n}>";
+    hilightSrcGreen = "<NUNumberSetting min:0 max:1 attributes:{\n    default = \"0.75\";\n    required = 0;\n}>";
+    hilightSrcRGB = "<NUNumberSetting min:0 max:1 attributes:{\n    default = \"0.75\";\n    required = 0;\n}>";
+    hilightSrcRed = "<NUNumberSetting min:0 max:1 attributes:{\n    default = \"0.75\";\n    required = 0;\n}>";
+    midDstBlue = "<NUNumberSetting min:0 max:1 attributes:{\n    default = \"0.5\";\n    required = 0;\n}>";
+    midDstGreen = "<NUNumberSetting min:0 max:1 attributes:{\n    default = \"0.5\";\n    required = 0;\n}>";
+    midDstRGB = "<NUNumberSetting min:0 max:1 attributes:{\n    default = \"0.5\";\n    required = 0;\n}>";
+    midDstRed = "<NUNumberSetting min:0 max:1 attributes:{\n    default = \"0.5\";\n    required = 0;\n}>";
+    midSrcBlue = "<NUNumberSetting min:0 max:1 attributes:{\n    default = \"0.5\";\n    required = 0;\n}>";
+    midSrcGreen = "<NUNumberSetting min:0 max:1 attributes:{\n    default = \"0.5\";\n    required = 0;\n}>";
+    midSrcRGB = "<NUNumberSetting min:0 max:1 attributes:{\n    default = \"0.5\";\n    required = 0;\n}>";
+    midSrcRed = "<NUNumberSetting min:0 max:1 attributes:{\n    default = \"0.5\";\n    required = 0;\n}>";
+    shadowDstBlue = "<NUNumberSetting min:0 max:1 attributes:{\n    default = \"0.25\";\n    required = 0;\n}>";
+    shadowDstGreen = "<NUNumberSetting min:0 max:1 attributes:{\n    default = \"0.25\";\n    required = 0;\n}>";
+    shadowDstRGB = "<NUNumberSetting min:0 max:1 attributes:{\n    default = \"0.25\";\n    required = 0;\n}>";
+    shadowDstRed = "<NUNumberSetting min:0 max:1 attributes:{\n    default = \"0.25\";\n    required = 0;\n}>";
+    shadowSrcBlue = "<NUNumberSetting min:0 max:1 attributes:{\n    default = \"0.25\";\n    required = 0;\n}>";
+    shadowSrcGreen = "<NUNumberSetting min:0 max:1 attributes:{\n    default = \"0.25\";\n    required = 0;\n}>";
+    shadowSrcRGB = "<NUNumberSetting min:0 max:1 attributes:{\n    default = \"0.25\";\n    required = 0;\n}>";
+    shadowSrcRed = "<NUNumberSetting min:0 max:1 attributes:{\n    default = \"0.25\";\n    required = 0;\n}>";
+    whiteDstBlue = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 1;\n    required = 0;\n}>";
+    whiteDstGreen = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 1;\n    required = 0;\n}>";
+    whiteDstRGB = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 1;\n    required = 0;\n}>";
+    whiteDstRed = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 1;\n    required = 0;\n}>";
+    whiteSrcBlue = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 1;\n    required = 0;\n}>";
+    whiteSrcGreen = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 1;\n    required = 0;\n}>";
+    whiteSrcRGB = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 1;\n    required = 0;\n}>";
+    whiteSrcRed = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 1;\n    required = 0;\n}>";
+}
+videoPosterFrame = {
+    scale = "<NUNumberSetting min:1 max:2147483647 attributes:{\n    default = 1;\n}>";
+    time = "<NUNumberSetting min:0 max:9223372036854775807 attributes:{\n}>";
+}
+redEye = {
+    auto = "<NUBoolSetting attributes:{\n    required = 0;\n}>";
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+    iPhone = "<NUBoolSetting attributes:{\n    required = 0;\n}>";
+    inputCorrectionInfo = "<NUOpaqueSetting attributes:{\n    required = 0;\n}>";
+}
+smartBlackAndWhite = {
+    auto = "<NUBoolSetting attributes:{\n    required = 0;\n}>";
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+    grain = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 0;\n}>";
+    hue = "<NUNumberSetting min:-1 max:1 attributes:{\n    default = 0;\n}>";
+    neutral = "<NUNumberSetting min:-1 max:1 attributes:{\n    default = 0;\n}>";
+    strength = "<NUNumberSetting min:0 max:1 attributes:{\n    default = \"0.5\";\n}>";
+    tone = "<NUNumberSetting min:-1 max:1 attributes:{\n    default = 0;\n}>";
+}
+orientation = {
+    value = "<NUNumberSetting min:1 max:8 attributes:{\n    default = 1;\n}>";
+}
+curves = {
+    auto = "<NUBoolSetting attributes:{\n    required = 0;\n}>";
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+    pointsB = "<NUArraySetting content:<NUCompoundSetting properties:{\n    editable = \"<NUBoolSetting attributes:{\\n}>\";\n    x = \"<NUNumberSetting min:0 max:2 attributes:{\\n}>\";\n    y = \"<NUNumberSetting min:0 max:2 attributes:{\\n}>\";\n} attributes:{\n}> attributes:{\n}>";
+    pointsG = "<NUArraySetting content:<NUCompoundSetting properties:{\n    editable = \"<NUBoolSetting attributes:{\\n}>\";\n    x = \"<NUNumberSetting min:0 max:2 attributes:{\\n}>\";\n    y = \"<NUNumberSetting min:0 max:2 attributes:{\\n}>\";\n} attributes:{\n}> attributes:{\n}>";
+    pointsL = "<NUArraySetting content:<NUCompoundSetting properties:{\n    editable = \"<NUBoolSetting attributes:{\\n}>\";\n    x = \"<NUNumberSetting min:0 max:2 attributes:{\\n}>\";\n    y = \"<NUNumberSetting min:0 max:2 attributes:{\\n}>\";\n} attributes:{\n}> attributes:{\n}>";
+    pointsR = "<NUArraySetting content:<NUCompoundSetting properties:{\n    editable = \"<NUBoolSetting attributes:{\\n}>\";\n    x = \"<NUNumberSetting min:0 max:2 attributes:{\\n}>\";\n    y = \"<NUNumberSetting min:0 max:2 attributes:{\\n}>\";\n} attributes:{\n}> attributes:{\n}>";
+}
+noiseReduction = {
+    auto = "<NUBoolSetting attributes:{\n    required = 0;\n}>";
+    edgeDetail = "<NUNumberSetting min:0 max:6 attributes:{\n    default = \"1.5\";\n    required = 0;\n}>";
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+    radius = "<NUNumberSetting min:0 max:10 attributes:{\n    default = 1;\n}>";
+}
+selectiveColor = {
+    corrections = "<NUArraySetting content:<NUCompoundSetting properties:{\n    blue = \"<NUNumberSetting min:0 max:1 attributes:{\\n    required = 1;\\n}>\";\n    green = \"<NUNumberSetting min:0 max:1 attributes:{\\n    required = 1;\\n}>\";\n    hueShift = \"<NUNumberSetting min:-60 max:60 attributes:{\\n    default = 0;\\n    required = 1;\\n}>\";\n    luminance = \"<NUNumberSetting min:-70 max:70 attributes:{\\n    default = 0;\\n    required = 1;\\n}>\";\n    red = \"<NUNumberSetting min:0 max:1 attributes:{\\n    required = 1;\\n}>\";\n    saturation = \"<NUNumberSetting min:-100 max:100 attributes:{\\n    default = 0;\\n    required = 1;\\n}>\";\n    spread = \"<NUNumberSetting min:0 max:2 attributes:{\\n    default = 1;\\n    required = 1;\\n}>\";\n} attributes:{\n}> attributes:{\n}>";
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+}
+sourceSelect = {
+    inputImage = "<NUEnumSetting values:(\n    primary,\n    spatialOvercapture,\n    spatialOvercaptureFused\n) attributes:{\n}>";
+}
+apertureRedEye = {
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+    inputCorrectionInfo = "<NUArraySetting content:<NUCompoundSetting properties:{\n    pointX = \"<NUNumberSetting min:-999999999 max:999999999 attributes:{\\n}>\";\n    pointY = \"<NUNumberSetting min:-999999999 max:999999999 attributes:{\\n}>\";\n    radius = \"<NUNumberSetting min:0 max:999999999 attributes:{\\n}>\";\n    sensitivity = \"<NUNumberSetting min:0 max:1 attributes:{\\n}>\";\n} attributes:{\n}> attributes:{\n    required = 0;\n}>";
+}
+depthEffect = {
+    aperture = "<NUNumberSetting min:0.8 max:22 attributes:{\n    required = 0;\n}>";
+    depthInfo = "<NUOpaqueSetting attributes:{\n}>";
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+}
+smartColor = {
+    auto = "<NUBoolSetting attributes:{\n    required = 0;\n}>";
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+    inputCast = "<NUNumberSetting min:-1 max:2 attributes:{\n    default = 0;\n}>";
+    inputColor = "<NUNumberSetting min:-1 max:1 attributes:{\n    default = 0;\n}>";
+    inputContrast = "<NUNumberSetting min:-1 max:2 attributes:{\n    default = 0;\n}>";
+    inputSaturation = "<NUNumberSetting min:-1 max:2 attributes:{\n    default = 0;\n}>";
+    offsetCast = "<NUNumberSetting min:-1 max:2 attributes:{\n    default = 0;\n}>";
+    offsetContrast = "<NUNumberSetting min:-2 max:2 attributes:{\n    default = 0;\n}>";
+    offsetSaturation = "<NUNumberSetting min:-2 max:2 attributes:{\n    default = 0;\n}>";
+    statistics = "<NUOpaqueSetting attributes:{\n    required = 0;\n}>";
+}
+portraitEffect = {
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+    kind = "<NUEnumSetting values:(\n    Light,\n    Commercial,\n    Contour,\n    Black,\n    BlackoutMono,\n    StudioV2,\n    ContourV2,\n    StageV2,\n    StageMonoV2,\n    StageWhite\n) attributes:{\n    default = Light;\n}>";
+    portraitInfo = "<NUOpaqueSetting attributes:{\n}>";
+    strength = "<NUNumberSetting min:0 max:1 attributes:{\n    required = 0;\n}>";
+    version = "<NUNumberSetting min:0 max:1 attributes:{\n    required = 0;\n}>";
+}
+raw = {
+    inputDecoderVersion = "<NUOpaqueSetting attributes:{\n}>";
+    inputSushiLevel = "<NUOpaqueSetting attributes:{\n    required = 0;\n}>";
+}
+trim = {
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+    end = "<NUNumberSetting min:0 max:9223372036854775807 attributes:{\n}>";
+    endScale = "<NUNumberSetting min:1 max:2147483647 attributes:{\n}>";
+    start = "<NUNumberSetting min:0 max:9223372036854775807 attributes:{\n}>";
+    startScale = "<NUNumberSetting min:1 max:2147483647 attributes:{\n}>";
+}
+effect = {
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+    intensity = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 1;\n    required = 0;\n}>";
+    kind = "<NUEnumSetting values:(\n    Mono,\n    Tonal,\n    Noir,\n    Fade,\n    Chrome,\n    Process,\n    Transfer,\n    Instant\n) attributes:{\n    default = Mono;\n}>";
+    version = "<NUNumberSetting min:0 max:2 attributes:{\n    required = 0;\n}>";
+}
+slomo = {
+    end = "<NUNumberSetting min:0 max:9223372036854775807 attributes:{\n}>";
+    endScale = "<NUNumberSetting min:1 max:2147483647 attributes:{\n}>";
+    rate = "<NUNumberSetting min:0.01 max:1 attributes:{\n}>";
+    start = "<NUNumberSetting min:0 max:9223372036854775807 attributes:{\n}>";
+    startScale = "<NUNumberSetting min:1 max:2147483647 attributes:{\n}>";
+}
+grain = {
+    amount = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 0;\n}>";
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+    iso = "<NUNumberSetting min:10 max:3200 attributes:{\n    default = 800;\n}>";
+    seed = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 0;\n    required = 0;\n}>";
+}
+videoReframe = {
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+    keyframes = "<NUArraySetting content:<NUCompoundSetting properties:{\n    homography = \"<NUArraySetting content:<NUNumberSetting min:-9223372036854775807 max:9223372036854775807 attributes:{\\n    default = 0;\\n}> attributes:{\\n}>\";\n    timeScale = \"<NUNumberSetting min:1 max:2147483647 attributes:{\\n}>\";\n    timeValue = \"<NUNumberSetting min:-9223372036854775807 max:9223372036854775807 attributes:{\\n}>\";\n} attributes:{\n}> attributes:{\n}>";
+    stabCropRect = "<NUCompoundSetting properties:{\n    Height = \"<NUNumberSetting min:-999999999 max:999999999 attributes:{\\n    default = 0;\\n}>\";\n    Width = \"<NUNumberSetting min:-999999999 max:999999999 attributes:{\\n    default = 0;\\n}>\";\n    X = \"<NUNumberSetting min:-999999999 max:999999999 attributes:{\\n    default = 0;\\n}>\";\n    Y = \"<NUNumberSetting min:-999999999 max:999999999 attributes:{\\n    default = 0;\\n}>\";\n} attributes:{\n}>";
+}
+rawNoiseReduction = {
+    auto = "<NUBoolSetting attributes:{\n    required = 0;\n}>";
+    color = "<NUNumberSetting min:-1 max:1 attributes:{\n    default = 0;\n}>";
+    contrast = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 0;\n    required = 0;\n}>";
+    detail = "<NUNumberSetting min:0 max:3 attributes:{\n    default = 0;\n}>";
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+    luminance = "<NUNumberSetting min:-0.1 max:1 attributes:{\n    default = 0;\n}>";
+    sharpness = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 0;\n    required = 0;\n}>";
+}
+cropStraighten = {
+    angle = "<NUNumberSetting min:-45 max:45 attributes:{\n    default = 0;\n}>";
+    auto = "<NUBoolSetting attributes:{\n    required = 0;\n}>";
+    constraintHeight = "<NUNumberSetting min:0 max:999999999 attributes:{\n    required = 0;\n}>";
+    constraintWidth = "<NUNumberSetting min:0 max:999999999 attributes:{\n    required = 0;\n}>";
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+    height = "<NUNumberSetting min:-999999999 max:999999999 attributes:{\n    default = 0;\n}>";
+    originalCrop = "<NUBoolSetting attributes:{\n    default = 0;\n    required = 0;\n}>";
+    pitch = "<NUNumberSetting min:-30 max:30 attributes:{\n    default = 0;\n    required = 0;\n}>";
+    smart = "<NUBoolSetting attributes:{\n    default = 0;\n    required = 0;\n}>";
+    width = "<NUNumberSetting min:-999999999 max:999999999 attributes:{\n    default = 0;\n}>";
+    xOrigin = "<NUNumberSetting min:-999999999 max:999999999 attributes:{\n    default = 0;\n}>";
+    yOrigin = "<NUNumberSetting min:-999999999 max:999999999 attributes:{\n    default = 0;\n}>";
+    yaw = "<NUNumberSetting min:-30 max:30 attributes:{\n    default = 0;\n    required = 0;\n}>";
+}
+highResFusion = {
+    alignment = "<NUOpaqueSetting attributes:{\n}>";
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+}
+sharpen = {
+    auto = "<NUBoolSetting attributes:{\n    required = 0;\n}>";
+    edges = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 1;\n}>";
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+    falloff = "<NUNumberSetting min:0 max:1 attributes:{\n    default = 1;\n}>";
+    intensity = "<NUNumberSetting min:0 max:2 attributes:{\n    default = 0;\n}>";
+}
+autoLoop = {
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+    flavor = "<NUEnumSetting values:(\n    AutoLoop,\n    Mirror,\n    LongExposure\n) attributes:{\n    default = AutoLoop;\n}>";
+    recipe = "<NUOpaqueSetting attributes:{\n}>";
+}
+retouch = {
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+    inputStrokes = "<NUArraySetting content:<NUCompoundSetting properties:{\n    mode = \"<NUEnumSetting values:(\\n    Repair\\n) attributes:{\\n}>\";\n    opacity = \"<NUNumberSetting min:0 max:1 attributes:{\\n}>\";\n    points = \"<NUArraySetting content:<NUCompoundSetting properties:{\\n    pressure = \\\"<NUNumberSetting min:0 max:1 attributes:{\\\\n    required = 0;\\\\n}>\\\";\\n    x = \\\"<NUNumberSetting min:-9223372036854775808 max:9223372036854775807 attributes:{\\\\n}>\\\";\\n    y = \\\"<NUNumberSetting min:-9223372036854775808 max:9223372036854775807 attributes:{\\\\n}>\\\";\\n} attributes:{\\n}> attributes:{\\n}>\";\n    radius = \"<NUNumberSetting min:0 max:4000 attributes:{\\n}>\";\n    repairEdges = \"<NUBoolSetting attributes:{\\n    default = 0;\\n    required = 0;\\n}>\";\n    softness = \"<NUNumberSetting min:0 max:1 attributes:{\\n}>\";\n    sourceOffset = \"<NUCompoundSetting properties:{\\n    x = \\\"<NUNumberSetting min:-9223372036854775808 max:9223372036854775807 attributes:{\\\\n}>\\\";\\n    y = \\\"<NUNumberSetting min:-9223372036854775808 max:9223372036854775807 attributes:{\\\\n}>\\\";\\n} attributes:{\\n}>\";\n    version = \"<NUNumberSetting min:1 max:10000 attributes:{\\n}>\";\n} attributes:{\n}> attributes:{\n    required = 0;\n}>";
+}
+smartTone = {
+    auto = "<NUBoolSetting attributes:{\n    required = 0;\n}>";
+    enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+    inputBlack = "<NUNumberSetting min:-10 max:10 attributes:{\n    default = 0;\n}>";
+    inputBrightness = "<NUNumberSetting min:-10 max:10 attributes:{\n    default = 0;\n}>";
+    inputContrast = "<NUNumberSetting min:-10 max:10 attributes:{\n    default = 0;\n}>";
+    inputExposure = "<NUNumberSetting min:-10 max:10 attributes:{\n    default = 0;\n}>";
+    inputHighlights = "<NUNumberSetting min:-10 max:10 attributes:{\n    default = 0;\n}>";
+    inputImage = "<NUEnumSetting values:(\n    primary,\n    spatialOvercapture,\n    spatialOvercaptureFused\n) attributes:{\n    required = 0;\n}>";
+    inputLight = "<NUNumberSetting min:-10 max:10 attributes:{\n    default = 0;\n}>";
+    inputLocalLight = "<NUNumberSetting min:-10 max:10 attributes:{\n    default = 0;\n    required = 0;\n}>";
+    inputRawHighlights = "<NUNumberSetting min:-10 max:10 attributes:{\n    default = 0;\n}>";
+    inputShadows = "<NUNumberSetting min:-10 max:10 attributes:{\n    default = 0;\n}>";
+    offsetBlack = "<NUNumberSetting min:-2 max:2 attributes:{\n    default = 0;\n}>";
+    offsetBrightness = "<NUNumberSetting min:-2 max:2 attributes:{\n    default = 0;\n}>";
+    offsetContrast = "<NUNumberSetting min:-2 max:2 attributes:{\n    default = 0;\n}>";
+    offsetExposure = "<NUNumberSetting min:-2 max:2 attributes:{\n    default = 0;\n}>";
+    offsetHighlights = "<NUNumberSetting min:-2 max:2 attributes:{\n    default = 0;\n}>";
+    offsetLocalLight = "<NUNumberSetting min:-2 max:2 attributes:{\n    default = 0;\n    required = 0;\n}>";
+    offsetShadows = "<NUNumberSetting min:-2 max:2 attributes:{\n    default = 0;\n}>";
+    overcaptureStatistics = "<NUOpaqueSetting attributes:{\n    required = 0;\n}>";
+    statistics = "<NUOpaqueSetting attributes:{\n    required = 0;\n}>";
+}
+
+```
+
+## Useful Framework Headers
+
+### PhotoKit
+
+* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/Frameworks/Photos/21/PHPhotoLibrary.h>
+* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/Frameworks/Photos/21/PHAsset.h>
+
+### NeutrinoCore
+
+* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUAdjustment.h>
+* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUGenericAdjustment.h>
+* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUAdjustmentSchema.h>
+* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUAdjustmentSerialization.h>
+* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUComposition.h>
+* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUGenericComposition.h>
+* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUCompositionSchema.h>
+
+TODO: May be able to use `NUAdjustmentSerialization` directly to load and adjustment plist file from disk and bypass
+the permissions and other hacks for PhotoKit.
+
+
+## Debugging
+
+Raw notes/output from poking at things in the debugger
+
+### PHPhotoLibrary
+
+```
+(lldb) po [PHPhotoLibrary.self performSelector:@selector(PHObjectClassesByEntityName)]
+{
+    Album = PHAssetCollection;
+    Asset = PHAsset;
+    CloudSharedAlbum = PHCloudSharedAlbum;
+    DetectedFace = PHFace;
+    DetectedFaceGroup = PHFaceGroup;
+    FaceCrop = PHFaceCrop;
+    FetchingAlbum = PHAssetCollection;
+    Folder = PHCollectionList;
+    GenericAsset = PHAsset;
+    ImportSession = PHImportSession;
+    Keyword = PHKeyword;
+    LegacyFaceAlbum = PHAssetCollection;
+    Memory = PHMemory;
+    Moment = PHMoment;
+    MomentList = PHMomentList;
+    MomentShare = PHMomentShare;
+    MomentShareParticipant = PHMomentShareParticipant;
+    Person = PHPerson;
+    PhotoStreamAlbum = PHAssetCollection;
+    PhotosHighlight = PHPhotosHighlight;
+    ProjectAlbum = PHProject;
+    Question = PHQuestion;
+    Suggestion = PHSuggestion;
+}
+```
+
+### Adjustments
+
+Notes:
+* `val` is the "composition" entry from the `-adjustmentsDebugMetadata` dictionary for a `PHAsset`.
+* suspect the `me.neilpa.photohack` instead of `com.apple.photos` for most namesaces is from the dynamic loading of arbitrary `*.photoslibrary`
+
+Given an asset that has adjustments, it appears straightforward to decode. 
+
+```
+(lldb) po [val class]
+NUGenericComposition
+
+(lldb) po [val contents]
+{
+    cropStraighten = "<NUGenericAdjustment:0x10063a740> id=me.neilpa.photohack:CropStraighten~1.0 settings={\n    angle = \"-0\";\n    auto = 0;\n    constraintHeight = 0;\n    constraintW...";
+    orientation = "<NUGenericAdjustment:0x10063aa70> id=me.neilpa.photohack:Orientation~1.0 settings={\n    value = 1;\n}";
+    raw = "<NUGenericAdjustment:0x10063a4e0> id=me.neilpa.photohack:RAW~1.0 settings={\n    auto = 0;\n    enabled = 1;\n    inputDecoderVersion = 8;\n}";
+}
+
+(lldb) po [[val contents] objectForKey:@"cropStraighten"]
+<NUGenericAdjustment:0x10063a740> id=me.neilpa.photohack:CropStraighten~1.0 settings={
+    angle = "-0";
+    auto = 0;
+    constraintHeight = 0;
+    constraintWidth = 0;
+    enabled = 1;
+    height = 988;
+    width = 1482;
+    xOrigin = 2342;
+    yOrigin = 1127;
+}
+
+(lldb)  po [[[[val contents] objectForKey:@"cropStraighten"] schema] class]
+NUAdjustmentSchema
+
+(lldb) po [[[[val contents] objectForKey:@"cropStraighten"] schema] settings]
+{
+   angle = "<NUNumberSetting min:-45 max:45 attributes:{\n    default = 0;\n}>";
+   auto = "<NUBoolSetting attributes:{\n    required = 0;\n}>";
+   constraintHeight = "<NUNumberSetting min:0 max:999999999 attributes:{\n    required = 0;\n}>";
+   constraintWidth = "<NUNumberSetting min:0 max:999999999 attributes:{\n    required = 0;\n}>";
+   enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+   height = "<NUNumberSetting min:-999999999 max:999999999 attributes:{\n    default = 0;\n}>";
+   originalCrop = "<NUBoolSetting attributes:{\n    default = 0;\n    required = 0;\n}>";
+   pitch = "<NUNumberSetting min:-30 max:30 attributes:{\n    default = 0;\n    required = 0;\n}>";
+   smart = "<NUBoolSetting attributes:{\n    default = 0;\n    required = 0;\n}>";
+   width = "<NUNumberSetting min:-999999999 max:999999999 attributes:{\n    default = 0;\n}>";
+   xOrigin = "<NUNumberSetting min:-999999999 max:999999999 attributes:{\n    default = 0;\n}>";
+   yOrigin = "<NUNumberSetting min:-999999999 max:999999999 attributes:{\n    default = 0;\n}>";
+   yaw = "<NUNumberSetting min:-30 max:30 attributes:{\n    default = 0;\n    required = 0;\n}>";
+}
+```
+
+The composition also has a schema which seems to expose the entire array of possible adjustments. E.g, for
+every key in the `-contents` dictionary of an `NUCompositionSchema`, the associated adjustment schema
+can be looked up with `[[schema modelForProperty:key] settings]`.
+
+```objective-c
+#define dump(fmt, ...) CFShow((__bridge CFStringRef)[NSString stringWithFormat:fmt, ##__VA_ARGS__])
+
+id compSchema = [composition performSelector:@selector(schema)];
+for (NSString *key in [compSchema contents]) {
+    id adjSchema = ((id (*)(id, SEL, id))objc_msgSend)(compSchema, @selector(modelForProperty:), key);
+    if (![adjSchema respondsToSelector:@selector(settings)]) {
+        continue; // NUSourceSchema
+    }
+    dump(@"%@ = %@", key, [adjSchema settings]);
+}
+```
+
+
+```
+(lldb) po [[val schema] class]
+NUCompositionSchema
+
+(lldb) po [[val schema] contents]
+{
+   apertureRedEye = "me.neilpa.photohack:ApertureRedEye~1.0";
+   autoLoop = "me.neilpa.photohack:AutoLoop~1.0";
+   cropStraighten = "me.neilpa.photohack:CropStraighten~1.0";
+   curves = "me.neilpa.photohack:Curves~1.0";
+   definition = "me.neilpa.photohack:Definition~1.0";
+   depthEffect = "me.neilpa.photohack:DepthEffect~1.0";
+   effect = "me.neilpa.photohack:Effect~1.0";
+   effect3D = "me.neilpa.photohack:Effect3D~1.0";
+   grain = "me.neilpa.photohack:Grain~1.0";
+   highResFusion = "me.neilpa.photohack:HighResolutionFusion~1.0";
+   levels = "me.neilpa.photohack:Levels~1.0";
+   livePhotoKeyFrame = "me.neilpa.photohack:LivePhotoKeyFrame~1.0";
+   mute = "me.neilpa.photohack:Mute~1.0";
+   noiseReduction = "me.neilpa.photohack:NoiseReduction~1.0";
+   orientation = "me.neilpa.photohack:Orientation~1.0";
+   portraitEffect = "me.neilpa.photohack:PortraitEffect~1.0";
+   raw = "me.neilpa.photohack:RAW~1.0";
+   rawNoiseReduction = "me.neilpa.photohack:RawNoiseReduction~1.0";
+   redEye = "me.neilpa.photohack:RedEye~1.0";
+   reference = "com.apple.photo:Source~1.0";
+   retouch = "me.neilpa.photohack:Retouch~1.0";
+   selectiveColor = "me.neilpa.photohack:SelectiveColor~1.0";
+   sharpen = "me.neilpa.photohack:Sharpen~1.0";
+   slomo = "me.neilpa.photohack:SlowMotion~1.0";
+   smartBlackAndWhite = "me.neilpa.photohack:SmartBlackAndWhite~1.0";
+   smartColor = "me.neilpa.photohack:SmartColor~1.0";
+   smartTone = "me.neilpa.photohack:SmartTone~1.0";
+   source = "com.apple.photo:Source~1.0";
+   sourceSelect = "me.neilpa.photohack:SourceSelect~1.0";
+   sourceSpatialOvercapture = "com.apple.photo:Source~1.0";
+   trim = "me.neilpa.photohack:Trim~1.0";
+   videoPosterFrame = "me.neilpa.photohack:VideoPosterFrame~1.0";
+   videoReframe = "me.neilpa.photohack:VideoReframe~1.0";
+   vignette = "me.neilpa.photohack:Vignette~1.0";
+   whiteBalance = "me.neilpa.photohack:WhiteBalance~1.0";
+}
+
+(lldb) po [[val schema] requiredContents]
+{(
+   source
+)}
+
+
+(lldb) po [[val schema] schemaDependencies]
+<__NSArrayI 0x100567a80>(
+NUIdentifier ns:me.neilpa.photohack name:Effect3D version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:LivePhotoKeyFrame version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:Mute version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:WhiteBalance version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:Vignette version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:Definition version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:Levels version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:VideoPosterFrame version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:RedEye version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:SmartBlackAndWhite version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:Orientation version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:Curves version:1.0>,
+NUIdentifier ns:com.apple.photo name:Source version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:NoiseReduction version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:SelectiveColor version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:SourceSelect version:1.0>,
+NUIdentifier ns:com.apple.photo name:Source version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:ApertureRedEye version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:DepthEffect version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:SmartColor version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:PortraitEffect version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:RAW version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:Trim version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:Effect version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:SlowMotion version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:Grain version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:VideoReframe version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:RawNoiseReduction version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:CropStraighten version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:HighResolutionFusion version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:Sharpen version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:AutoLoop version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:Retouch version:1.0>,
+NUIdentifier ns:com.apple.photo name:Source version:1.0>,
+NUIdentifier ns:me.neilpa.photohack name:SmartTone version:1.0>
+)
+
+(lldb) po [[[val schema] modelForProperty:@"whiteBalance"] class]
+NUAdjustmentSchema
+
+(lldb) po [[[val schema] modelForProperty:@"whiteBalance"] settings]
+{
+   auto = "<NUBoolSetting attributes:{\n    required = 0;\n}>";
+   colorType = "<NUEnumSetting values:(\n    neutralGray,\n    faceBalance,\n    tempTint,\n    warmTint\n) attributes:{\n    default = faceBalance;\n}>";
+   enabled = "<NUBoolSetting attributes:{\n    default = 0;\n}>";
+   faceI = "<NUNumberSetting min:-3 max:3 attributes:{\n    required = 0;\n}>";
+   faceQ = "<NUNumberSetting min:-2 max:2 attributes:{\n    required = 0;\n}>";
+   faceStrength = "<NUNumberSetting min:-3 max:3 attributes:{\n    required = 0;\n}>";
+   faceWarmth = "<NUNumberSetting min:-3 max:3 attributes:{\n    required = 0;\n}>";
+   grayI = "<NUNumberSetting min:-3 max:3 attributes:{\n    required = 0;\n}>";
+   grayQ = "<NUNumberSetting min:-3 max:3 attributes:{\n    required = 0;\n}>";
+   grayStrength = "<NUNumberSetting min:-3 max:3 attributes:{\n    default = 1;\n    required = 0;\n}>";
+   grayWarmth = "<NUNumberSetting min:-3 max:3 attributes:{\n    required = 0;\n}>";
+   grayY = "<NUNumberSetting min:-3 max:3 attributes:{\n    required = 0;\n}>";
+   temperature = "<NUNumberSetting min:1000 max:32000 attributes:{\n    default = 5000;\n    identity = 5000;\n    required = 0;\n}>";
+   tint = "<NUNumberSetting min:-150 max:150 attributes:{\n    default = 0;\n    required = 0;\n}>";
+   warmFace = "<NUBoolSetting attributes:{\n    default = 0;\n    required = 0;\n}>";
+   warmTemp = "<NUNumberSetting min:-2 max:2 attributes:{\n    default = 0;\n    required = 0;\n}>";
+   warmTint = "<NUNumberSetting min:-2 max:2 attributes:{\n    default = 0;\n    required = 0;\n}>";
+}
+```

--- a/README.md
+++ b/README.md
@@ -6,11 +6,40 @@ Experimenting with PhotoKit to load non-system photo libraries to decode adjustm
 photohack path/to/some.photoslibrary UUID...
 ```
 
+## Useful Framework Headers
+
+### PhotoKit
+
+* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/Frameworks/Photos/21/PHPhotoLibrary.h>
+* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/Frameworks/Photos/21/PHAsset.h>
+
+### NeutrinoCore
+
+* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUAdjustment.h>
+* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUGenericAdjustment.h>
+* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUAdjustmentSchema.h>
+* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUAdjustmentSerialization.h>
+
+* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUComposition.h>
+* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUGenericComposition.h>
+* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUCompositionSchema.h>
+
+* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUSetting.h>
+* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUBoolSetting.h>
+* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUEnumSetting.h>
+* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUNumberSetting.h>
+* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUOpaqueSetting.h>
+* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUArraySetting.h>
+* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUCompoundSetting.h>
+
+TODO: May be able to use `NUAdjustmentSerialization` directly to load and adjustment plist file from disk and bypass
+the permissions and other hacks for PhotoKit.
+
+
 ## Adjustments Schema
 
-See the debugging section below for a bit more details
-
-TODO: JSON-ify this so it's a bit easier to read
+See the debugging section below for a more detail or [`schema-adjustments.json`](schema-adjustments.json) for
+a JSON mapping of the following.
 
 ```
 effect3D = {
@@ -277,27 +306,6 @@ smartTone = {
 }
 
 ```
-
-## Useful Framework Headers
-
-### PhotoKit
-
-* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/Frameworks/Photos/21/PHPhotoLibrary.h>
-* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/Frameworks/Photos/21/PHAsset.h>
-
-### NeutrinoCore
-
-* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUAdjustment.h>
-* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUGenericAdjustment.h>
-* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUAdjustmentSchema.h>
-* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUAdjustmentSerialization.h>
-* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUComposition.h>
-* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUGenericComposition.h>
-* <https://github.com/w0lfschild/macOS_headers/blob/master/macOS/PrivateFrameworks/NeutrinoCore/21/NUCompositionSchema.h>
-
-TODO: May be able to use `NUAdjustmentSerialization` directly to load and adjustment plist file from disk and bypass
-the permissions and other hacks for PhotoKit.
-
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,44 @@
 # photohack
 
-Experimenting with PhotoKit to load non-system photo libraries to decode adjustment data and other useful info.
+Experimenting with PhotoKit to load non-system photo libraries to decode adjustment data (i.e. edited photos) and potentially other useful info.
 
 ```sh
-photohack path/to/some.photoslibrary UUID...
+photohack path/to/some.photoslibrary adjustments UUID...
 ```
+
+For a given set of UUIDs this will print a JSON object with the provided UUIDs as keys and values as adjustment objects, e.g
+
+```json
+{
+  "34B8483F-8A35-4FEB-98A3-84DC376F0C9F" : {
+    "raw" : {
+      "enabled" : true,
+      "auto" : false,
+      "inputDecoderVersion" : "8"
+    },
+    "cropStraighten" : {
+      "angle" : -0,
+      "height" : 988,
+      "enabled" : true,
+      "constraintWidth" : 0,
+      "width" : 1482,
+      "xOrigin" : 2342,
+      "yOrigin" : 1127,
+      "constraintHeight" : 0,
+      "auto" : false
+    },
+    "orientation" : {
+      "value" : 1
+    }
+  },
+  "E1C9A934-260F-4211-95AD-14827A82ACB4" : {
+
+  }
+}
+```
+
+Note, the empty object for the asset w/out any ajustments.
+
 
 ## Useful Framework Headers
 

--- a/adjustments-schema.json
+++ b/adjustments-schema.json
@@ -1,0 +1,1857 @@
+{
+  "apertureRedEye" : {
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    },
+    "inputCorrectionInfo" : {
+      "attributes" : {
+        "required" : false
+      },
+      "content" : {
+        "properties" : {
+          "pointX" : {
+            "max" : 999999999,
+            "min" : -999999999,
+            "type" : "number"
+          },
+          "pointY" : {
+            "max" : 999999999,
+            "min" : -999999999,
+            "type" : "number"
+          },
+          "radius" : {
+            "max" : 999999999,
+            "min" : 0,
+            "type" : "number"
+          },
+          "sensitivity" : {
+            "max" : 1,
+            "min" : 0,
+            "type" : "number"
+          }
+        },
+        "type" : "array"
+      },
+      "type" : "array"
+    }
+  },
+  "autoLoop" : {
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    },
+    "flavor" : {
+      "attributes" : {
+        "default" : "AutoLoop"
+      },
+      "type" : "enum",
+      "values" : [
+        "AutoLoop",
+        "Mirror",
+        "LongExposure"
+      ]
+    },
+    "recipe" : {
+      "type" : "opaque"
+    }
+  },
+  "cropStraighten" : {
+    "angle" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 45,
+      "min" : -45,
+      "type" : "number"
+    },
+    "auto" : {
+      "attributes" : {
+        "required" : false
+      },
+      "type" : "bool"
+    },
+    "constraintHeight" : {
+      "attributes" : {
+        "required" : false
+      },
+      "max" : 999999999,
+      "min" : 0,
+      "type" : "number"
+    },
+    "constraintWidth" : {
+      "attributes" : {
+        "required" : false
+      },
+      "max" : 999999999,
+      "min" : 0,
+      "type" : "number"
+    },
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    },
+    "height" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 999999999,
+      "min" : -999999999,
+      "type" : "number"
+    },
+    "originalCrop" : {
+      "attributes" : {
+        "default" : false,
+        "required" : false
+      },
+      "type" : "bool"
+    },
+    "pitch" : {
+      "attributes" : {
+        "default" : 0,
+        "required" : false
+      },
+      "max" : 30,
+      "min" : -30,
+      "type" : "number"
+    },
+    "smart" : {
+      "attributes" : {
+        "default" : false,
+        "required" : false
+      },
+      "type" : "bool"
+    },
+    "width" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 999999999,
+      "min" : -999999999,
+      "type" : "number"
+    },
+    "xOrigin" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 999999999,
+      "min" : -999999999,
+      "type" : "number"
+    },
+    "yaw" : {
+      "attributes" : {
+        "default" : 0,
+        "required" : false
+      },
+      "max" : 30,
+      "min" : -30,
+      "type" : "number"
+    },
+    "yOrigin" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 999999999,
+      "min" : -999999999,
+      "type" : "number"
+    }
+  },
+  "curves" : {
+    "auto" : {
+      "attributes" : {
+        "required" : false
+      },
+      "type" : "bool"
+    },
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    },
+    "pointsB" : {
+      "content" : {
+        "properties" : {
+          "editable" : {
+            "type" : "bool"
+          },
+          "x" : {
+            "max" : 2,
+            "min" : 0,
+            "type" : "number"
+          },
+          "y" : {
+            "max" : 2,
+            "min" : 0,
+            "type" : "number"
+          }
+        },
+        "type" : "array"
+      },
+      "type" : "array"
+    },
+    "pointsG" : {
+      "content" : {
+        "properties" : {
+          "editable" : {
+            "type" : "bool"
+          },
+          "x" : {
+            "max" : 2,
+            "min" : 0,
+            "type" : "number"
+          },
+          "y" : {
+            "max" : 2,
+            "min" : 0,
+            "type" : "number"
+          }
+        },
+        "type" : "array"
+      },
+      "type" : "array"
+    },
+    "pointsL" : {
+      "content" : {
+        "properties" : {
+          "editable" : {
+            "type" : "bool"
+          },
+          "x" : {
+            "max" : 2,
+            "min" : 0,
+            "type" : "number"
+          },
+          "y" : {
+            "max" : 2,
+            "min" : 0,
+            "type" : "number"
+          }
+        },
+        "type" : "array"
+      },
+      "type" : "array"
+    },
+    "pointsR" : {
+      "content" : {
+        "properties" : {
+          "editable" : {
+            "type" : "bool"
+          },
+          "x" : {
+            "max" : 2,
+            "min" : 0,
+            "type" : "number"
+          },
+          "y" : {
+            "max" : 2,
+            "min" : 0,
+            "type" : "number"
+          }
+        },
+        "type" : "array"
+      },
+      "type" : "array"
+    }
+  },
+  "definition" : {
+    "auto" : {
+      "attributes" : {
+        "required" : false
+      },
+      "type" : "bool"
+    },
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    },
+    "intensity" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 2,
+      "min" : 0,
+      "type" : "number"
+    }
+  },
+  "depthEffect" : {
+    "aperture" : {
+      "attributes" : {
+        "required" : false
+      },
+      "max" : 22,
+      "min" : 0.80000000000000004,
+      "type" : "number"
+    },
+    "depthInfo" : {
+      "type" : "opaque"
+    },
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    }
+  },
+  "effect" : {
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    },
+    "intensity" : {
+      "attributes" : {
+        "default" : 1,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "kind" : {
+      "attributes" : {
+        "default" : "Mono"
+      },
+      "type" : "enum",
+      "values" : [
+        "Mono",
+        "Tonal",
+        "Noir",
+        "Fade",
+        "Chrome",
+        "Process",
+        "Transfer",
+        "Instant"
+      ]
+    },
+    "version" : {
+      "attributes" : {
+        "required" : false
+      },
+      "max" : 2,
+      "min" : 0,
+      "type" : "number"
+    }
+  },
+  "effect3D" : {
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    },
+    "intensity" : {
+      "attributes" : {
+        "default" : 1,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "kind" : {
+      "attributes" : {
+        "default" : "3DVivid"
+      },
+      "type" : "enum",
+      "values" : [
+        "3DVivid",
+        "3DVividWarm",
+        "3DVividCool",
+        "3DDramatic",
+        "3DDramaticWarm",
+        "3DDramaticCool",
+        "3DSilverplate",
+        "3DNoir"
+      ]
+    },
+    "version" : {
+      "attributes" : {
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    }
+  },
+  "grain" : {
+    "amount" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    },
+    "iso" : {
+      "attributes" : {
+        "default" : 800
+      },
+      "max" : 3200,
+      "min" : 10,
+      "type" : "number"
+    },
+    "seed" : {
+      "attributes" : {
+        "default" : 0,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    }
+  },
+  "highResFusion" : {
+    "alignment" : {
+      "type" : "opaque"
+    },
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    }
+  },
+  "levels" : {
+    "auto" : {
+      "attributes" : {
+        "required" : false
+      },
+      "type" : "bool"
+    },
+    "blackDstBlue" : {
+      "attributes" : {
+        "default" : 0,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "blackDstGreen" : {
+      "attributes" : {
+        "default" : 0,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "blackDstRed" : {
+      "attributes" : {
+        "default" : 0,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "blackDstRGB" : {
+      "attributes" : {
+        "default" : 0,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "blackSrcBlue" : {
+      "attributes" : {
+        "default" : 0,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "blackSrcGreen" : {
+      "attributes" : {
+        "default" : 0,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "blackSrcRed" : {
+      "attributes" : {
+        "default" : 0,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "blackSrcRGB" : {
+      "attributes" : {
+        "default" : 0,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "colorSpace" : {
+      "attributes" : {
+        "default" : "Display P3",
+        "required" : false
+      },
+      "type" : "enum",
+      "values" : [
+        "Adobe RGB",
+        "sRGB",
+        "Display P3"
+      ]
+    },
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    },
+    "hilightDstBlue" : {
+      "attributes" : {
+        "default" : 0.75,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "hilightDstGreen" : {
+      "attributes" : {
+        "default" : 0.75,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "hilightDstRed" : {
+      "attributes" : {
+        "default" : 0.75,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "hilightDstRGB" : {
+      "attributes" : {
+        "default" : 0.75,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "hilightSrcBlue" : {
+      "attributes" : {
+        "default" : 0.75,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "hilightSrcGreen" : {
+      "attributes" : {
+        "default" : 0.75,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "hilightSrcRed" : {
+      "attributes" : {
+        "default" : 0.75,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "hilightSrcRGB" : {
+      "attributes" : {
+        "default" : 0.75,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "midDstBlue" : {
+      "attributes" : {
+        "default" : 0.5,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "midDstGreen" : {
+      "attributes" : {
+        "default" : 0.5,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "midDstRed" : {
+      "attributes" : {
+        "default" : 0.5,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "midDstRGB" : {
+      "attributes" : {
+        "default" : 0.5,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "midSrcBlue" : {
+      "attributes" : {
+        "default" : 0.5,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "midSrcGreen" : {
+      "attributes" : {
+        "default" : 0.5,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "midSrcRed" : {
+      "attributes" : {
+        "default" : 0.5,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "midSrcRGB" : {
+      "attributes" : {
+        "default" : 0.5,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "shadowDstBlue" : {
+      "attributes" : {
+        "default" : 0.25,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "shadowDstGreen" : {
+      "attributes" : {
+        "default" : 0.25,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "shadowDstRed" : {
+      "attributes" : {
+        "default" : 0.25,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "shadowDstRGB" : {
+      "attributes" : {
+        "default" : 0.25,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "shadowSrcBlue" : {
+      "attributes" : {
+        "default" : 0.25,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "shadowSrcGreen" : {
+      "attributes" : {
+        "default" : 0.25,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "shadowSrcRed" : {
+      "attributes" : {
+        "default" : 0.25,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "shadowSrcRGB" : {
+      "attributes" : {
+        "default" : 0.25,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "whiteDstBlue" : {
+      "attributes" : {
+        "default" : 1,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "whiteDstGreen" : {
+      "attributes" : {
+        "default" : 1,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "whiteDstRed" : {
+      "attributes" : {
+        "default" : 1,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "whiteDstRGB" : {
+      "attributes" : {
+        "default" : 1,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "whiteSrcBlue" : {
+      "attributes" : {
+        "default" : 1,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "whiteSrcGreen" : {
+      "attributes" : {
+        "default" : 1,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "whiteSrcRed" : {
+      "attributes" : {
+        "default" : 1,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "whiteSrcRGB" : {
+      "attributes" : {
+        "default" : 1,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    }
+  },
+  "livePhotoKeyFrame" : {
+    "scale" : {
+      "attributes" : {
+        "default" : 1
+      },
+      "max" : 2147483647,
+      "min" : 1,
+      "type" : "number"
+    },
+    "time" : {
+      "max" : 9223372036854775807,
+      "min" : 0,
+      "type" : "number"
+    }
+  },
+  "mute" : {
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    }
+  },
+  "noiseReduction" : {
+    "auto" : {
+      "attributes" : {
+        "required" : false
+      },
+      "type" : "bool"
+    },
+    "edgeDetail" : {
+      "attributes" : {
+        "default" : 1.5,
+        "required" : false
+      },
+      "max" : 6,
+      "min" : 0,
+      "type" : "number"
+    },
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    },
+    "radius" : {
+      "attributes" : {
+        "default" : 1
+      },
+      "max" : 10,
+      "min" : 0,
+      "type" : "number"
+    }
+  },
+  "orientation" : {
+    "value" : {
+      "attributes" : {
+        "default" : 1
+      },
+      "max" : 8,
+      "min" : 1,
+      "type" : "number"
+    }
+  },
+  "portraitEffect" : {
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    },
+    "kind" : {
+      "attributes" : {
+        "default" : "Light"
+      },
+      "type" : "enum",
+      "values" : [
+        "Light",
+        "Commercial",
+        "Contour",
+        "Black",
+        "BlackoutMono",
+        "StudioV2",
+        "ContourV2",
+        "StageV2",
+        "StageMonoV2",
+        "StageWhite"
+      ]
+    },
+    "portraitInfo" : {
+      "type" : "opaque"
+    },
+    "strength" : {
+      "attributes" : {
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "version" : {
+      "attributes" : {
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    }
+  },
+  "raw" : {
+    "inputDecoderVersion" : {
+      "type" : "opaque"
+    },
+    "inputSushiLevel" : {
+      "attributes" : {
+        "required" : false
+      },
+      "type" : "opaque"
+    }
+  },
+  "rawNoiseReduction" : {
+    "auto" : {
+      "attributes" : {
+        "required" : false
+      },
+      "type" : "bool"
+    },
+    "color" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 1,
+      "min" : -1,
+      "type" : "number"
+    },
+    "contrast" : {
+      "attributes" : {
+        "default" : 0,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "detail" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 3,
+      "min" : 0,
+      "type" : "number"
+    },
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    },
+    "luminance" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 1,
+      "min" : -0.10000000000000001,
+      "type" : "number"
+    },
+    "sharpness" : {
+      "attributes" : {
+        "default" : 0,
+        "required" : false
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    }
+  },
+  "redEye" : {
+    "auto" : {
+      "attributes" : {
+        "required" : false
+      },
+      "type" : "bool"
+    },
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    },
+    "inputCorrectionInfo" : {
+      "attributes" : {
+        "required" : false
+      },
+      "type" : "opaque"
+    },
+    "iPhone" : {
+      "attributes" : {
+        "required" : false
+      },
+      "type" : "bool"
+    }
+  },
+  "retouch" : {
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    },
+    "inputStrokes" : {
+      "attributes" : {
+        "required" : false
+      },
+      "content" : {
+        "properties" : {
+          "mode" : {
+            "type" : "enum",
+            "values" : [
+              "Repair"
+            ]
+          },
+          "opacity" : {
+            "max" : 1,
+            "min" : 0,
+            "type" : "number"
+          },
+          "points" : {
+            "content" : {
+              "properties" : {
+                "pressure" : {
+                  "attributes" : {
+                    "required" : false
+                  },
+                  "max" : 1,
+                  "min" : 0,
+                  "type" : "number"
+                },
+                "x" : {
+                  "max" : 9223372036854775807,
+                  "min" : -9223372036854775808,
+                  "type" : "number"
+                },
+                "y" : {
+                  "max" : 9223372036854775807,
+                  "min" : -9223372036854775808,
+                  "type" : "number"
+                }
+              },
+              "type" : "array"
+            },
+            "type" : "array"
+          },
+          "radius" : {
+            "max" : 4000,
+            "min" : 0,
+            "type" : "number"
+          },
+          "repairEdges" : {
+            "attributes" : {
+              "default" : false,
+              "required" : false
+            },
+            "type" : "bool"
+          },
+          "softness" : {
+            "max" : 1,
+            "min" : 0,
+            "type" : "number"
+          },
+          "sourceOffset" : {
+            "properties" : {
+              "x" : {
+                "max" : 9223372036854775807,
+                "min" : -9223372036854775808,
+                "type" : "number"
+              },
+              "y" : {
+                "max" : 9223372036854775807,
+                "min" : -9223372036854775808,
+                "type" : "number"
+              }
+            },
+            "type" : "array"
+          },
+          "version" : {
+            "max" : 10000,
+            "min" : 1,
+            "type" : "number"
+          }
+        },
+        "type" : "array"
+      },
+      "type" : "array"
+    }
+  },
+  "selectiveColor" : {
+    "corrections" : {
+      "content" : {
+        "properties" : {
+          "blue" : {
+            "attributes" : {
+              "required" : true
+            },
+            "max" : 1,
+            "min" : 0,
+            "type" : "number"
+          },
+          "green" : {
+            "attributes" : {
+              "required" : true
+            },
+            "max" : 1,
+            "min" : 0,
+            "type" : "number"
+          },
+          "hueShift" : {
+            "attributes" : {
+              "default" : 0,
+              "required" : true
+            },
+            "max" : 60,
+            "min" : -60,
+            "type" : "number"
+          },
+          "luminance" : {
+            "attributes" : {
+              "default" : 0,
+              "required" : true
+            },
+            "max" : 70,
+            "min" : -70,
+            "type" : "number"
+          },
+          "red" : {
+            "attributes" : {
+              "required" : true
+            },
+            "max" : 1,
+            "min" : 0,
+            "type" : "number"
+          },
+          "saturation" : {
+            "attributes" : {
+              "default" : 0,
+              "required" : true
+            },
+            "max" : 100,
+            "min" : -100,
+            "type" : "number"
+          },
+          "spread" : {
+            "attributes" : {
+              "default" : 1,
+              "required" : true
+            },
+            "max" : 2,
+            "min" : 0,
+            "type" : "number"
+          }
+        },
+        "type" : "array"
+      },
+      "type" : "array"
+    },
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    }
+  },
+  "sharpen" : {
+    "auto" : {
+      "attributes" : {
+        "required" : false
+      },
+      "type" : "bool"
+    },
+    "edges" : {
+      "attributes" : {
+        "default" : 1
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    },
+    "falloff" : {
+      "attributes" : {
+        "default" : 1
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "intensity" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 2,
+      "min" : 0,
+      "type" : "number"
+    }
+  },
+  "slomo" : {
+    "end" : {
+      "max" : 9223372036854775807,
+      "min" : 0,
+      "type" : "number"
+    },
+    "endScale" : {
+      "max" : 2147483647,
+      "min" : 1,
+      "type" : "number"
+    },
+    "rate" : {
+      "max" : 1,
+      "min" : 0.01,
+      "type" : "number"
+    },
+    "start" : {
+      "max" : 9223372036854775807,
+      "min" : 0,
+      "type" : "number"
+    },
+    "startScale" : {
+      "max" : 2147483647,
+      "min" : 1,
+      "type" : "number"
+    }
+  },
+  "smartBlackAndWhite" : {
+    "auto" : {
+      "attributes" : {
+        "required" : false
+      },
+      "type" : "bool"
+    },
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    },
+    "grain" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "hue" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 1,
+      "min" : -1,
+      "type" : "number"
+    },
+    "neutral" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 1,
+      "min" : -1,
+      "type" : "number"
+    },
+    "strength" : {
+      "attributes" : {
+        "default" : 0.5
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "tone" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 1,
+      "min" : -1,
+      "type" : "number"
+    }
+  },
+  "smartColor" : {
+    "auto" : {
+      "attributes" : {
+        "required" : false
+      },
+      "type" : "bool"
+    },
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    },
+    "inputCast" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 2,
+      "min" : -1,
+      "type" : "number"
+    },
+    "inputColor" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 1,
+      "min" : -1,
+      "type" : "number"
+    },
+    "inputContrast" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 2,
+      "min" : -1,
+      "type" : "number"
+    },
+    "inputSaturation" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 2,
+      "min" : -1,
+      "type" : "number"
+    },
+    "offsetCast" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 2,
+      "min" : -1,
+      "type" : "number"
+    },
+    "offsetContrast" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 2,
+      "min" : -2,
+      "type" : "number"
+    },
+    "offsetSaturation" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 2,
+      "min" : -2,
+      "type" : "number"
+    },
+    "statistics" : {
+      "attributes" : {
+        "required" : false
+      },
+      "type" : "opaque"
+    }
+  },
+  "smartTone" : {
+    "auto" : {
+      "attributes" : {
+        "required" : false
+      },
+      "type" : "bool"
+    },
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    },
+    "inputBlack" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 10,
+      "min" : -10,
+      "type" : "number"
+    },
+    "inputBrightness" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 10,
+      "min" : -10,
+      "type" : "number"
+    },
+    "inputContrast" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 10,
+      "min" : -10,
+      "type" : "number"
+    },
+    "inputExposure" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 10,
+      "min" : -10,
+      "type" : "number"
+    },
+    "inputHighlights" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 10,
+      "min" : -10,
+      "type" : "number"
+    },
+    "inputImage" : {
+      "attributes" : {
+        "required" : false
+      },
+      "type" : "enum",
+      "values" : [
+        "primary",
+        "spatialOvercapture",
+        "spatialOvercaptureFused"
+      ]
+    },
+    "inputLight" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 10,
+      "min" : -10,
+      "type" : "number"
+    },
+    "inputLocalLight" : {
+      "attributes" : {
+        "default" : 0,
+        "required" : false
+      },
+      "max" : 10,
+      "min" : -10,
+      "type" : "number"
+    },
+    "inputRawHighlights" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 10,
+      "min" : -10,
+      "type" : "number"
+    },
+    "inputShadows" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 10,
+      "min" : -10,
+      "type" : "number"
+    },
+    "offsetBlack" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 2,
+      "min" : -2,
+      "type" : "number"
+    },
+    "offsetBrightness" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 2,
+      "min" : -2,
+      "type" : "number"
+    },
+    "offsetContrast" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 2,
+      "min" : -2,
+      "type" : "number"
+    },
+    "offsetExposure" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 2,
+      "min" : -2,
+      "type" : "number"
+    },
+    "offsetHighlights" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 2,
+      "min" : -2,
+      "type" : "number"
+    },
+    "offsetLocalLight" : {
+      "attributes" : {
+        "default" : 0,
+        "required" : false
+      },
+      "max" : 2,
+      "min" : -2,
+      "type" : "number"
+    },
+    "offsetShadows" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 2,
+      "min" : -2,
+      "type" : "number"
+    },
+    "overcaptureStatistics" : {
+      "attributes" : {
+        "required" : false
+      },
+      "type" : "opaque"
+    },
+    "statistics" : {
+      "attributes" : {
+        "required" : false
+      },
+      "type" : "opaque"
+    }
+  },
+  "sourceSelect" : {
+    "inputImage" : {
+      "type" : "enum",
+      "values" : [
+        "primary",
+        "spatialOvercapture",
+        "spatialOvercaptureFused"
+      ]
+    }
+  },
+  "trim" : {
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    },
+    "end" : {
+      "max" : 9223372036854775807,
+      "min" : 0,
+      "type" : "number"
+    },
+    "endScale" : {
+      "max" : 2147483647,
+      "min" : 1,
+      "type" : "number"
+    },
+    "start" : {
+      "max" : 9223372036854775807,
+      "min" : 0,
+      "type" : "number"
+    },
+    "startScale" : {
+      "max" : 2147483647,
+      "min" : 1,
+      "type" : "number"
+    }
+  },
+  "videoPosterFrame" : {
+    "scale" : {
+      "attributes" : {
+        "default" : 1
+      },
+      "max" : 2147483647,
+      "min" : 1,
+      "type" : "number"
+    },
+    "time" : {
+      "max" : 9223372036854775807,
+      "min" : 0,
+      "type" : "number"
+    }
+  },
+  "videoReframe" : {
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    },
+    "keyframes" : {
+      "content" : {
+        "properties" : {
+          "homography" : {
+            "content" : {
+              "attributes" : {
+                "default" : 0
+              },
+              "max" : 9223372036854775807,
+              "min" : -9223372036854775807,
+              "type" : "number"
+            },
+            "type" : "array"
+          },
+          "timeScale" : {
+            "max" : 2147483647,
+            "min" : 1,
+            "type" : "number"
+          },
+          "timeValue" : {
+            "max" : 9223372036854775807,
+            "min" : -9223372036854775807,
+            "type" : "number"
+          }
+        },
+        "type" : "array"
+      },
+      "type" : "array"
+    },
+    "stabCropRect" : {
+      "properties" : {
+        "Height" : {
+          "attributes" : {
+            "default" : 0
+          },
+          "max" : 999999999,
+          "min" : -999999999,
+          "type" : "number"
+        },
+        "Width" : {
+          "attributes" : {
+            "default" : 0
+          },
+          "max" : 999999999,
+          "min" : -999999999,
+          "type" : "number"
+        },
+        "X" : {
+          "attributes" : {
+            "default" : 0
+          },
+          "max" : 999999999,
+          "min" : -999999999,
+          "type" : "number"
+        },
+        "Y" : {
+          "attributes" : {
+            "default" : 0
+          },
+          "max" : 999999999,
+          "min" : -999999999,
+          "type" : "number"
+        }
+      },
+      "type" : "array"
+    }
+  },
+  "vignette" : {
+    "auto" : {
+      "attributes" : {
+        "required" : false
+      },
+      "type" : "bool"
+    },
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    },
+    "falloff" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    },
+    "intensity" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 1,
+      "min" : -1,
+      "type" : "number"
+    },
+    "radius" : {
+      "attributes" : {
+        "default" : 0
+      },
+      "max" : 1,
+      "min" : 0,
+      "type" : "number"
+    }
+  },
+  "whiteBalance" : {
+    "auto" : {
+      "attributes" : {
+        "required" : false
+      },
+      "type" : "bool"
+    },
+    "colorType" : {
+      "attributes" : {
+        "default" : "faceBalance"
+      },
+      "type" : "enum",
+      "values" : [
+        "neutralGray",
+        "faceBalance",
+        "tempTint",
+        "warmTint"
+      ]
+    },
+    "enabled" : {
+      "attributes" : {
+        "default" : false
+      },
+      "type" : "bool"
+    },
+    "faceI" : {
+      "attributes" : {
+        "required" : false
+      },
+      "max" : 3,
+      "min" : -3,
+      "type" : "number"
+    },
+    "faceQ" : {
+      "attributes" : {
+        "required" : false
+      },
+      "max" : 2,
+      "min" : -2,
+      "type" : "number"
+    },
+    "faceStrength" : {
+      "attributes" : {
+        "required" : false
+      },
+      "max" : 3,
+      "min" : -3,
+      "type" : "number"
+    },
+    "faceWarmth" : {
+      "attributes" : {
+        "required" : false
+      },
+      "max" : 3,
+      "min" : -3,
+      "type" : "number"
+    },
+    "grayI" : {
+      "attributes" : {
+        "required" : false
+      },
+      "max" : 3,
+      "min" : -3,
+      "type" : "number"
+    },
+    "grayQ" : {
+      "attributes" : {
+        "required" : false
+      },
+      "max" : 3,
+      "min" : -3,
+      "type" : "number"
+    },
+    "grayStrength" : {
+      "attributes" : {
+        "default" : 1,
+        "required" : false
+      },
+      "max" : 3,
+      "min" : -3,
+      "type" : "number"
+    },
+    "grayWarmth" : {
+      "attributes" : {
+        "required" : false
+      },
+      "max" : 3,
+      "min" : -3,
+      "type" : "number"
+    },
+    "grayY" : {
+      "attributes" : {
+        "required" : false
+      },
+      "max" : 3,
+      "min" : -3,
+      "type" : "number"
+    },
+    "temperature" : {
+      "attributes" : {
+        "default" : 5000,
+        "identity" : 5000,
+        "required" : false
+      },
+      "max" : 32000,
+      "min" : 1000,
+      "type" : "number"
+    },
+    "tint" : {
+      "attributes" : {
+        "default" : 0,
+        "required" : false
+      },
+      "max" : 150,
+      "min" : -150,
+      "type" : "number"
+    },
+    "warmFace" : {
+      "attributes" : {
+        "default" : false,
+        "required" : false
+      },
+      "type" : "bool"
+    },
+    "warmTemp" : {
+      "attributes" : {
+        "default" : 0,
+        "required" : false
+      },
+      "max" : 2,
+      "min" : -2,
+      "type" : "number"
+    },
+    "warmTint" : {
+      "attributes" : {
+        "default" : 0,
+        "required" : false
+      },
+      "max" : 2,
+      "min" : -2,
+      "type" : "number"
+    }
+  }
+}

--- a/photohack.xcodeproj/project.pbxproj
+++ b/photohack.xcodeproj/project.pbxproj
@@ -252,7 +252,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.0.1;
+				MARKETING_VERSION = 0.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = me.neilpa.photohack;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "photohack/photohack-Bridging-Header.h";
@@ -273,7 +273,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.0.1;
+				MARKETING_VERSION = 0.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = me.neilpa.photohack;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "photohack/photohack-Bridging-Header.h";

--- a/photohack.xcodeproj/project.pbxproj
+++ b/photohack.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		BE443220251AF4E600D616A3 /* photohack-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "photohack-Bridging-Header.h"; sourceTree = "<group>"; };
 		BE443221251AF4E600D616A3 /* PhotoProxy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PhotoProxy.m; sourceTree = "<group>"; };
 		BE443223251AF51100D616A3 /* PhotoProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PhotoProxy.h; sourceTree = "<group>"; };
+		BECBC58D251D55C9009DF972 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -34,6 +35,7 @@
 		BE44320B251AF40C00D616A3 = {
 			isa = PBXGroup;
 			children = (
+				BECBC58D251D55C9009DF972 /* README.md */,
 				BE443216251AF40C00D616A3 /* photohack */,
 				BE443215251AF40C00D616A3 /* Products */,
 			);

--- a/photohack.xcodeproj/project.pbxproj
+++ b/photohack.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		BE443218251AF40C00D616A3 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE443217251AF40C00D616A3 /* main.swift */; };
-		BE443222251AF4E600D616A3 /* PhotoProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = BE443221251AF4E600D616A3 /* PhotoProxy.m */; };
+		BEA22EFB251C148300F44A6C /* PhotoProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = BE443221251AF4E600D616A3 /* PhotoProxy.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -118,7 +118,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BE443218251AF40C00D616A3 /* main.swift in Sources */,
-				BE443222251AF4E600D616A3 /* PhotoProxy.m in Sources */,
+				BEA22EFB251C148300F44A6C /* PhotoProxy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/photohack/Info.plist
+++ b/photohack/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleName</key>
 	<string>photohack</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.2</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Lets hack a photo library</string>
 </dict>

--- a/photohack/PhotoProxy.h
+++ b/photohack/PhotoProxy.h
@@ -2,11 +2,20 @@
 
 @interface PhotoProxy : NSObject
 
+//
+// Static methods to interogate photos library schema/metadata
+//
+
 // Dump the database entity name to PH* class mapping
 + (NSDictionary*) entityToClass;
 
-+ (PhotoProxy*) fromPath:(NSString*)path;
+//
+// Working with an individual (potentially non-default) photos library
+//
 
+// Open the *.photoslibrary package at the given path
++ (PhotoProxy*) fromPath:(NSString*)path;
+// Extract adjustment dictionaries for a set of UUIDs in the photos library=
 - (void) dumpAdjustments:(NSArray*)uuids;
 
 @end

--- a/photohack/PhotoProxy.h
+++ b/photohack/PhotoProxy.h
@@ -15,7 +15,7 @@
 
 // Open the *.photoslibrary package at the given path
 + (PhotoProxy*) fromPath:(NSString*)path;
-// Extract adjustment dictionaries for a set of UUIDs in the photos library=
-- (void) dumpAdjustments:(NSArray*)uuids;
+// Returns a mapping of provided UUID values to adjustment dictionaries.
+- (NSDictionary*) fetchAdjustments:(NSArray*)uuids;
 
 @end

--- a/photohack/PhotoProxy.m
+++ b/photohack/PhotoProxy.m
@@ -5,6 +5,10 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wundeclared-selector"
 
+// Convert the composition, adjustment and settings schema to a plain dictionaries.
+NSDictionary* resolveSchema(id composition);
+NSDictionary* resolveSetting(id setting);
+
 @implementation PhotoProxy {
     NSString *path;
     PHPhotoLibrary *lib;
@@ -48,19 +52,86 @@
             return;
         }
 
-        id composition = [metadata objectForKey:@"composition"];
+        id composition = metadata[@"composition"];
         if (composition == nil) {
             dump(@"  <no-composition>");
             return;
         }
-        
-        NSDictionary* adjustments = [composition contents];
+
+        // To dump the full schema for all the adjustments
+        //NSError* err;
+        //NSData* json = [NSJSONSerialization dataWithJSONObject:resolveSchema(composition) options:NSJSONWritingPrettyPrinted|NSJSONWritingSortedKeys error:&err];
+        //dump([[NSString alloc] initWithData:json encoding:NSUTF8StringEncoding]);
+
+        // TODO Dictionary-ify this as well for a JSON representation
+        NSDictionary *adjustments = [composition contents];
         dump(@"  %@", adjustments);
     }];
-
 }
 
-
 @end
+
+// TODO: Align with json-schema.org?
+NSDictionary* resolveSchema(id composition) {
+    NSMutableDictionary *schema = [NSMutableDictionary dictionary];
+
+    id compSchema = [composition performSelector:@selector(schema)];
+    for (NSString *key in [compSchema contents]) {
+        id adjSchema = ((id (*)(id, SEL, id))objc_msgSend)(compSchema, @selector(modelForProperty:), key);
+        if (![adjSchema respondsToSelector:@selector(settings)]) {
+            continue; // NUSourceSchema
+        }
+
+        NSMutableDictionary *settings = [NSMutableDictionary dictionary];
+        for (NSString *skey in [adjSchema settings]) {
+            settings[skey] = resolveSetting([adjSchema settings][skey]);
+        }
+        schema[key] = [settings copy];
+    }
+    
+    return schema;
+}
+
+NSDictionary* resolveSetting(id setting) {
+    NSString *type = [setting className];
+    NSMutableDictionary *dict = [NSMutableDictionary dictionary];
+    if ([[setting attributes] count] > 0) {
+        dict[@"attributes"] = [setting attributes];
+    }
+
+    if ([@"NUBoolSetting" isEqualToString:type]) {
+        dict[@"type"] = @"bool";
+
+    } else if ([@"NUNumberSetting" isEqualToString:type]) {
+        dict[@"type"] = @"number";
+        dict[@"min"] = [setting performSelector:@selector(minimumValue)];
+        dict[@"max"] = [setting performSelector:@selector(maximumValue)];
+
+    } else if ([@"NUEnumSetting" isEqualToString:type]) {
+        dict[@"type"] = @"enum";
+        dict[@"values"] = [setting values];
+
+    } else if ([@"NUOpaqueSetting" isEqualToString:type]) {
+        dict[@"type"] = @"opaque";
+
+    } else if ([@"NUArraySetting" isEqualToString:type]) {
+        dict[@"type"] = @"array";
+        dict[@"content"] = resolveSetting([setting performSelector:@selector(content)]);
+
+    } else if ([@"NUCompoundSetting" isEqualToString:type]) {
+        dict[@"type"] = @"array";
+        NSDictionary *props = [setting properties];
+        NSMutableDictionary *propDict = [NSMutableDictionary dictionary];
+        for (NSString *key in props) {
+            propDict[key] = resolveSetting(props[key]);
+        }
+        dict[@"properties"] = propDict;
+
+    } else {
+        NSLog(@"unknown setting class: %@", type);
+    }
+    
+    return [dict copy];
+}
 
 #pragma clang diagnostic pop

--- a/photohack/main.swift
+++ b/photohack/main.swift
@@ -3,7 +3,8 @@ import Foundation
 import Photos
 
 if CommandLine.arguments.count < 3 {
-    print("usage: photoproxy <*.photoslibrary> <UUID>...")
+    print("usage: photoproxy <*.photoslibrary> <cmd> [<arg>...]")
+    print("\t<cmd> is one of `adjustments`, ...")
     exit(1)
 }
 
@@ -38,7 +39,6 @@ PHPhotoLibrary.requestAuthorization({(status:PHAuthorizationStatus) in
 })
 sem.wait();
 
-//print(PhotoProxy.entityToClass() as AnyObject)
 
 let dbPath = CommandLine.arguments[1]
 let proxy = PhotoProxy.fromPath(dbPath)
@@ -47,5 +47,14 @@ if proxy == nil {
     exit(2)
 }
 
-let uuids = CommandLine.arguments.dropFirst(2).map { UUID(uuidString: $0)! };
-proxy!.dumpAdjustments(uuids)
+let cmd = CommandLine.arguments[2]
+switch cmd {
+case "adjustments":
+    let uuids = CommandLine.arguments.dropFirst(3).map { UUID(uuidString: $0)! }
+    
+    let adjustments = proxy!.fetchAdjustments(uuids)
+    let json = try JSONSerialization.data(withJSONObject: adjustments!, options: .prettyPrinted)
+    print(String(data: json, encoding: .utf8)!)
+default:
+    print("Invalid command: \(cmd)")
+}

--- a/photohack/main.swift
+++ b/photohack/main.swift
@@ -1,8 +1,9 @@
 import Foundation
+
 import Photos
 
 if CommandLine.arguments.count < 3 {
-    print("usage: photoproxy [photoslib] [UUID]...")
+    print("usage: photoproxy <*.photoslibrary> <UUID>...")
     exit(1)
 }
 
@@ -21,7 +22,8 @@ do {
     let url = URL.init(fileURLWithPath: "Info.plist", relativeTo: b.resourceURL)
     try plist.write(to: url)
 } catch {
-    print(error)
+    print("Failed to extract plist \(error)")
+    exit(2)
 }
 
 let sem = DispatchSemaphore(value: 0);
@@ -38,7 +40,12 @@ sem.wait();
 
 //print(PhotoProxy.entityToClass() as AnyObject)
 
-let proxy = PhotoProxy.fromPath(CommandLine.arguments[1])!
-let uuids = CommandLine.arguments.dropFirst(2).map { UUID(uuidString: $0)! };
+let dbPath = CommandLine.arguments[1]
+let proxy = PhotoProxy.fromPath(dbPath)
+if proxy == nil {
+    print("Failed to load photos library: \(dbPath)")
+    exit(2)
+}
 
-proxy.dumpAdjustments(uuids)
+let uuids = CommandLine.arguments.dropFirst(2).map { UUID(uuidString: $0)! };
+proxy!.dumpAdjustments(uuids)


### PR DESCRIPTION
The [README](https://github.com/neilpa/photohack/blob/5655455d2642e43660eb8cec6f6d25f7f2c0193d/README.md) contains most of the details. This decodes the adjustment data as a JSON map for a given set of asset UUIDs.

Additionally there's notes, links, debug spew, and helper function that extracted the entire array of ajdustment possibilities in the Photos app. Note the "array" and "compound" adjustments may not be right as those are more complicated and haven't been tested yet.